### PR TITLE
Add -q | --quiet cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ $ instant <port>
 If the port is omitted a free random port is used and
 `http://localhost:<random-port>` is opened in the default browser.
 
+### Options
+* `-q | --quiet`: Hide listening message. If no port is provided, the port will be displayed.
+
 ### Features
 
 * Supports all major browsers including Android 2 and IE6

--- a/bin/instant
+++ b/bin/instant
@@ -3,9 +3,17 @@
 var instant = require('instant')
   , connect = require('connect')
   , linger = require('linger')
+  , minimist = require('minimist')
   , open = require('open')
 
-var port = process.argv[2]
+var argv = minimist(process.argv.slice(2), {
+  boolean: 'quiet',
+  alias: {
+    quiet: 'q'
+  }
+})
+
+var port = argv._[0]
 var root = process.cwd()
 var app = connect()
 
@@ -14,6 +22,9 @@ app
 .use(connect.directory(root, { icons: true, hidden: true }))
 .listen(port, function() {
   var listening = this.address().port
-  if (!port) open('http://localhost:'+listening)
+  if (!port) open('http://localhost:' + listening)
+  if (argv.quiet && !port)
+  console.log('listening on port ' + listening + ' and waiting for changes')
+  else if (!argv.quiet)
   linger('listening on port ' + listening + ' and waiting for changes')
 })

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "url": "http://github.com/fgnass/instant-server.git"
   },
   "dependencies": {
-    "linger": "~0.0.3",
-    "open": "~0.0.3",
+    "connect": "~2.8.4",
     "instant": "~1.1.0",
-    "connect": "~2.8.4"
+    "linger": "~0.0.3",
+    "minimist": "^1.1.1",
+    "open": "~0.0.3"
   }
 }


### PR DESCRIPTION
These options are handy if you want to background the listening
and work from your shell, for example `instant -q & vi index.html`.

If a port is provided, no message is displayed. If no port is
provided, the port is logged and no further output displayed.
